### PR TITLE
EXT-6451-Change content in Note Section for Toolbox Configuration UG

### DIFF
--- a/aspnet/Visual-Studio-Integration/Toolbox-Configuration.md
+++ b/aspnet/Visual-Studio-Integration/Toolbox-Configuration.md
@@ -54,5 +54,6 @@ To add the Syncfusion ASP.NET Web Forms components via the Syncfusion Toolbox In
    ![Toolbox Installer](Toolbox-Configuration_images/Toolbox-Configuration_img3.png)
    
    
-   N> * You must reset the toolbox, when the installed components  are not reflected properly in the Toolbox. * This tool configures only the components  that are located under {Installed Location}\Assemblies\{Framework version}.
+   N> * If your installed controls are not reflected properly in the Visual Studio Toolbox, you'll have to reset the Toolbox. 
+   * This tool configures only the components  that are located under {Installed Location}\Assemblies\{Framework version}.
    


### PR DESCRIPTION
Changed content in note section as per customer requested

**Existing content:** You must reset the toolbox, when the installed controls are not reflected properly in the Toolbox.

**Replaced content:** If your installed controls are not reflected properly in the Visual Studio Toolbox, you'll have to reset the Toolbox. 