### PR TITLE
SEO-186239-ASP.NETWebForms-Splitter-Description-too-short

### DIFF
--- a/aspnet/Splitter/Appearance-and-Styling.md
+++ b/aspnet/Splitter/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Appearance and Styling | Splitter | ASP.NET | Syncfusion
-description: appearance and styling
+description: Learn here all about appearance and styling in ASP.NETWebForms Splitter Control, it's element and more
 platform: aspnet
 control: Splitter
 documentation: ug

--- a/aspnet/Splitter/Appearance-and-Styling.md
+++ b/aspnet/Splitter/Appearance-and-Styling.md
@@ -84,7 +84,7 @@ The following screenshot displays the output of the above code example.
 
 The output for Splitter when EnableAutoResize is “True”.
 
-![](Appearance-and-Styling_images/Appearance-and-Styling_img1.png)
+![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img1.png)
 
 
 
@@ -140,7 +140,7 @@ In an ASPX page, define the Splitter control and add the contents corresponding
 
 The output for Splitter when EnableAnimation is “True”. Expanding or collapsing the outer pane in the Splitter produces the animation effect with the animation speed.
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img3.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img3.png)
 
 
 
@@ -206,19 +206,19 @@ In an ASPX page, define the Splitter control and add the contents corresponding
 
 The output for Splitter after adding the properties.
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img4.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img4.png)
 
 
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img5.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img5.png)
 
 
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img6.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img6.png)
 
 
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img7.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img7.png)
 
 
 
@@ -316,7 +316,7 @@ Define CSS class for customizing the Splitter.
 
 The output for Splitter after customizing the CSS class.
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img8.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img8.png)
 
 
 
@@ -432,7 +432,7 @@ $(document).on("keydown", function (e) {
 
 Run the sample and press Alt + J to focus the Splitter control. Perform provided functionality by using keyboard shortcuts.
 
- ![](Appearance-and-Styling_images/Appearance-and-Styling_img9.png)
+ ![ASP.NETWebForms Splitter appearance and styling Control](Appearance-and-Styling_images/Appearance-and-Styling_img9.png)
 
 
 


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Site Audite|
|Content Task Link/Mail Screenshot | NA |
|Hotfix | https://github.com/syncfusion-content/asp.netwebforms-docs/pull/519|
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/186239|
|Work link | https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BDB18C9FA-0832-4384-89A4-DAB778CFEFD8%7D&file=Faith.xlsx&action=default&mobileredirect=true|

Title | Description
-- | --
|Task Category | Site Audite|
|Content Task Link/Mail Scr
Changes made | Reason for change
-- | --
| Page with redirect| To increase page performance |