### PR TITLE
SEO-18702-ASP.NET-Gantt-Exporting-Description-too-long

### DIFF
--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Exporting in ASP.NET Web Forms Gantt Control.
+# Exporting in ASP.NET Web Forms Gantt Control
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 
@@ -56,7 +56,7 @@ The below code snippet explains the above behavior,
 {% endtabs %} 
 
 The below screen shot shows Gantt with excel and PDF exporting enabled.
-![Exporting in ASP.NET Web Forms Gantt Control](Export_images/Export_img1.png)
+![Exporting in ASP.NET Web Forms Gantt Control.](Export_images/Export_img1.png)
 
 ## Server dependencies
 Export Helper functions are available in the Assembly `Syncfusion.EJ.Export`, which is available in the Essential Studio & Essential ASP.NET builds. The list of assemblies needed for Gantt Export as follows

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -1,12 +1,12 @@
 ---
 layout: post
 title: Exporting| Gantt | ASP.NET | Syncfusion
-description: Learn here about Exporting with the Syncfusion ASP.NET Web Forms Gantt control, its elements, and more.
+description: Learn here about exporting support in Syncfusion ASP.NET Web Forms Gantt control, its elements, and more.
 platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Exporting Sf ASP.NET Web Forms Gantt
+# ASP.NET Gantt-Invokes export public method of Gantt object to export.
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 
@@ -56,7 +56,7 @@ The below code snippet explains the above behavior,
 {% endtabs %} 
 
 The below screen shot shows Gantt with excel and PDF exporting enabled.
-![Export in ASP.NET Web Forms Gantt Exporting](Export_images/Export_img1.png)
+![PDF exporting enabled in ASP.NET Web Forms Gantt Exporting](Export_images/Export_img1.png)
 
 ## Server dependencies
 Export Helper functions are available in the Assembly `Syncfusion.EJ.Export`, which is available in the Essential Studio & Essential ASP.NET builds. The list of assemblies needed for Gantt Export as follows

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Exporting| Gantt | ASP.NET | Syncfusion
-description: exporting
+description: Learn here about Exporting with the Syncfusion ASP.NET Web Forms Gantt control, its elements, and more.
 platform: aspnet
 control: Gantt
 documentation: ug

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Exporting in ASP.NET Web forms Gantt Control
+# Exporting in ASP.NET Web Forms Gantt Control
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -56,7 +56,7 @@ The below code snippet explains the above behavior,
 {% endtabs %} 
 
 The below screen shot shows Gantt with excel and PDF exporting enabled.
-![PDF exporting enabled in ASP.NET Web Forms Gantt](Export_images/Export_img1.png)
+![Exporting in ASP.NET Web Forms Gantt Control](Export_images/Export_img1.png)
 
 ## Server dependencies
 Export Helper functions are available in the Assembly `Syncfusion.EJ.Export`, which is available in the Essential Studio & Essential ASP.NET builds. The list of assemblies needed for Gantt Export as follows

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Exporting in ASP.NET Webforms Gantt Control
+# Exporting in ASP.NET Web forms Gantt Control
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Exporting in ASP.NET Web forms Gantt Control
+# Exporting in ASP.NET Webforms Gantt Control
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Export
+# Exporting Sf ASP.NET Web Forms Gantt
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Update H1 as Exporting in ASP.NET Web Forms Gantt Control.
+# Exporting in ASP.NET Web Forms Gantt Control.
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Exporting in ASP.NET Webforms Gantt Control | Syncfusion
-description: Learn here all about exporting support in Syncfusion Essential ASP.NET Webforms Gantt Control, its elements, and more.
+title: Exporting in ASP.NET Web Forms Gantt Control | Syncfusion
+description: Learn here all about exporting support in Syncfusion Essential ASP.NET Web Forms Gantt Control, its elements, and more.
 platform: aspnet
 control: Gantt
 documentation: ug

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: Exporting| Gantt | ASP.NET | Syncfusion
-description: Learn here about exporting support in Syncfusion ASP.NET Web Forms Gantt control, its elements, and more.
+title: Exporting in ASP.NET Webforms Gantt Control | Syncfusion
+description: Learn here all about exporting support in Syncfusion Essential ASP.NET Webforms Gantt Control, its elements, and more.
 platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# Exporting in ASP.NET Web Forms Gantt Control
+# Exporting in ASP.NET Webforms Gantt Control
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -6,7 +6,7 @@ platform: aspnet
 control: Gantt
 documentation: ug
 ---
-# ASP.NET Gantt-Invokes export public method of Gantt object to export.
+# Update H1 as Exporting in ASP.NET Web Forms Gantt Control.
 
 Exporting feature provides support to export Gantt content to excel and PDF files. To export the contents, the `ExcelExport` and `PdfExport` toolbar items must be added in the toolbar using the `ToolbarItems` property of `ToolbarSettings`. When you click, the toolbar exporting icons, it internally invokes the export public method of Gantt object to export.
 
@@ -56,7 +56,7 @@ The below code snippet explains the above behavior,
 {% endtabs %} 
 
 The below screen shot shows Gantt with excel and PDF exporting enabled.
-![PDF exporting enabled in ASP.NET Web Forms Gantt Exporting](Export_images/Export_img1.png)
+![PDF exporting enabled in ASP.NET Web Forms Gantt](Export_images/Export_img1.png)
 
 ## Server dependencies
 Export Helper functions are available in the Assembly `Syncfusion.EJ.Export`, which is available in the Essential Studio & Essential ASP.NET builds. The list of assemblies needed for Gantt Export as follows

--- a/aspnet/Gantt/Exporting.md
+++ b/aspnet/Gantt/Exporting.md
@@ -56,7 +56,7 @@ The below code snippet explains the above behavior,
 {% endtabs %} 
 
 The below screen shot shows Gantt with excel and PDF exporting enabled.
-![](Export_images/Export_img1.png)
+![Export in ASP.NET Web Forms Gantt Exporting](Export_images/Export_img1.png)
 
 ## Server dependencies
 Export Helper functions are available in the Assembly `Syncfusion.EJ.Export`, which is available in the Essential Studio & Essential ASP.NET builds. The list of assemblies needed for Gantt Export as follows


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Site Audite|
|Content Task Link/Mail Screenshot | NA|
|Hotfix |https://github.com/syncfusion-content/asp.netwebforms-docs/pull/520|
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/187172|
|Work link |https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BCE6E5440-7D4E-43FE-B673-E79BCD0BF05D%7D&file=Faith-Site%20Audit.xlsx&action=default&mobileredirect=true&wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1722849150540&web=1|

Title | Description
-- | --
|Task Category | Site Audite|
|Content Task Link/Mail Scr
Changes made | Reason for change
-- | --
| Page with redirect| To increase page performance |