### PR TITLE
SEO-202684-Aspnet-dropdownlist-description too short

### DIFF
--- a/aspnet/DropDownList/ServerFiltering.md
+++ b/aspnet/DropDownList/ServerFiltering.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Searching in DropDownList | Syncfusion | ASP.NET WebForms
-description: Checkout and learn here all about how to describe about the searching in the DropDownList control for Syncfusion ASP.NET WebForm.
+description: Checkout and learn here all about how to describe the searching in the DropDownList control for Syncfusion ASP.NET WebForm.
 platform: aspnet
 control: DropDownList
 documentation: ug


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Meta description too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/asp.netwebforms-docs/pull/581 |
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/202684|
|Excel/SharePoint link| |

|Changes made|Reason for changes|
|--|--|
|Adding character in the description count |  To get the right description character count from 100-160 |     



Regards,
Hillary