### PR TITLE
Seo-203714-Netwebform-H1tag-missing-Hotfix

### DIFF
--- a/aspnet/Grid/How-to/Getting-Datasource-of-Grid-in-Sorted-order.md
+++ b/aspnet/Grid/How-to/Getting-Datasource-of-Grid-in-Sorted-order.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Datasource of Grid in Sorted Order | Grid | ASP.NET Webforms | Syncfusion
-description: Getting Datasource of Grid in Sorted Order
+title: Getting Datasource of Grid in Sorted Order | ASP.NET Webforms 
+description: Check out and learn all about getting the data source of a grid in sorted order in Syncfusion ASP.NET Web Forms and more details.
 platform: aspnet
 control: Grid
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK

Title | Description
-- | --
|Task Category |H1 tag missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204026/|
|Share point|[Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it.  | 




Regards, 
Asha