### PR TITLE
SEO-204026-Image-Alt-Missing-ASP.NET-Web form-Hotfix 

### DIFF
--- a/aspnet/Gantt/Editing.md
+++ b/aspnet/Gantt/Editing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Editing | Gantt | ASP.NET Webforms | Syncfusion
-description: editing
+description: Check out and learn here all about editing the Syncfusion ASP.NET Web Forms Gantt and much more details. 
 platform: aspnet
 control: Gantt
 documentation: ug
@@ -32,7 +32,7 @@ Update the task details through grid cell editing by setting `EditSettings.EditM
 {% endhighlight %}
 
 The output of Gantt with cell editing is as follows.
-![](Editing_images/Editing_img1.png)
+![cell editing.](Editing_images/Editing_img1.png)
 
 ### Save editing cell
 
@@ -116,7 +116,7 @@ Update the task details through edit dialog by setting `EditMode` as `normal`. T
 
 The following screenshot shows the output of `normal` editing.
 
-![](Editing_images/Editing_img2.png)
+![normal editing in gantt control.](Editing_images/Editing_img2.png)
 
 ### Define required fields in add/edit dialog
 
@@ -139,7 +139,7 @@ In Gantt we can define the editing fields available in add and edit dialogs by u
 {% endhighlight %}
 
 The following screenshot show the output of above code example.
-![](Editing_images/Editing_img4.png)
+![add and edit dialogs.](Editing_images/Editing_img4.png)
 
 N> Similarly we can define the required fields in add dialog with `AddDialogFields.Field` and `AddDialogFields.EditType` properties.
 
@@ -175,7 +175,7 @@ function load(args) {
 {% endhighlight %}
 
 The following screenshot show the output of above code example.
-![](Editing_images/Editing_img5.png)
+![custom column fields.](Editing_images/Editing_img5.png)
 
 N> Similarly we can include custom fields in add dialog's General tab by setting `DisplayInGeneralTab` as `true` in `AddDialogFields` collection.
 
@@ -273,7 +273,7 @@ In Gantt, we can add, edit, update the task dependencies by mouse interactions, 
 
 Task dependency can be added by mouse interactions by connecting connector points in predecessor and successor tasks. The following screen shot shows the add dependency action.
 
-![](Editing_images/Editing_img3.png)
+![dependency.](Editing_images/Editing_img3.png)
 
 ### Edit Dependency
 
@@ -306,13 +306,13 @@ function actionBegin(args) {
 {% endhighlight %}
 
 The following screen shot shows the dependency edit dialog.
-![](Editing_images/Predecessor_Editing_Dialog.png)
+![editing dependency.](Editing_images/Predecessor_Editing_Dialog.png)
 
 ### Delete Dependency
 
 Task dependency can be deleted by using edit dialog and [`deleteDependency`](/api/js/ejgantt#methods:deletedependency) method. The following screen shot shows the dependency edit dialog with delete option.
 
-![](Editing_images/Predecessor_Editing_Dialog.png)
+![delete dependency.](Editing_images/Predecessor_Editing_Dialog.png)
 
 [Click](https://asp.syncfusion.com/demos/web/gantt/editing.aspx) here to view the online demo sample for editing in Gantt.
 
@@ -378,7 +378,7 @@ The following code snippet explains how to enable delete confirmation message in
 
 {% endhighlight %}
 
-![](Editing_images/deleteConfirmation.png)
+![delete confirmation.](Editing_images/deleteConfirmation.png)
 
 The above screen shot shows the appearance of delete confirmation message in Gantt.
 
@@ -409,12 +409,12 @@ $("#indentTask").click(function () {
 
 The following screenshots shows the output of above code example.
 
-![](Editing_images/Editing_img6.png)
+![task delete option.](Editing_images/Editing_img6.png)
 
 Before Indent
 {:.caption}
 
-![](Editing_images/Editing_img7.png)
+![after delete option in gantt.](Editing_images/Editing_img7.png)
 
 After Indent
 {:.caption}

--- a/aspnet/Gantt/Predecessor.md
+++ b/aspnet/Gantt/Predecessor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Predecessor
-description: Predecessor
+title: Predecessor | Gantt | Syncfusion 
+description: Check out and learn here all about the predecessor of Syncfusion ASP.NET Webforms Gantt and much more details.
 platform: js
 control: Gantt
 documentation: ug
@@ -41,7 +41,7 @@ var data = [
 
 The following screen shot depicts the duration unit support in the predecessor offset.
 
-![](Predecessor_images/Predecessor_img1.png)
+![depicts the duration unit support in the predecessor offset.](Predecessor_images/Predecessor_img1.png)
 
 ## Validate predecessor links on editing
 
@@ -140,7 +140,7 @@ The following code example explains this.
 
 In this case, if the user dragging action violated the predecessor type then the following dialog will be rendered to perform operation.
 
-![](Predecessor_images/Predecessor_img2.png)
+![validation dialog.](Predecessor_images/Predecessor_img2.png)
 
 
 

--- a/aspnet/Grid/How-to/Add-comments-in-the-exported-file.md
+++ b/aspnet/Grid/How-to/Add-comments-in-the-exported-file.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Add comments in the Exported file (Excel, Word or Pdf) | Grid | ASP.NET Webforms | Syncfusion
-description: Add comments in the Exported file (Excel, Word or Pdf)
+title: Add comments in the Exported file | Grid | Syncfusion
+description: Check out and learn here all about add comments in the exported file (Excel, Word or Pdf) of Syncfusion ASP.NET Web Forms and much more details.
 platform: aspnet
 control: Grid
 documentation: ug
@@ -57,7 +57,7 @@ Using the Range property and AddComment method of the XlsIO IRange Class, we wil
 
 The following screenshot displays the exported grid with comments added to cells
 
-![](Add-comments-in-the-Exported-file_images/Add-comments-in-the-Exported-file_img1.png)
+![exported grid with comments added to cell.](Add-comments-in-the-Exported-file_images/Add-comments-in-the-Exported-file_img1.png)
 
 ## Adding Comments in Exported Word document
 
@@ -105,7 +105,7 @@ We can add comments to the word document using the AppendComment method in the W
 
 The following screenshot shows the exported grid with comments added to the document.
 
-![](Add-comments-in-the-Exported-file_images/Add-comments-in-the-Exported-file_img2.png)
+![exported grid with comments added to the document.](Add-comments-in-the-Exported-file_images/Add-comments-in-the-Exported-file_img2.png)
 
 ## Adding Comments in Exported PDF document
 
@@ -164,4 +164,4 @@ We can add comments to a PDF documents using the annotation support provided in 
 
 The following screenshot displays the exported grid with comments added to cells
 
-![](Add-comments-in-the-Exported-file_images/Add-comments-in-the-Exported-file_img3.png)
+![the exported grid with comments added to cells.](Add-comments-in-the-Exported-file_images/Add-comments-in-the-Exported-file_img3.png)

--- a/aspnet/Slider/Getting-Started.md
+++ b/aspnet/Slider/Getting-Started.md
@@ -15,7 +15,7 @@ ASP.NET Slider control provides support to display a Slider within the web pa
 
 The following screenshot demonstrates the functionality of Slider control. By selecting mobile model in the dropdown, you can purchase a mobile at any rate specified in the MobilePriceSlider. In addition, you can also specify the number of mobiles required by using the MobileCountSlider. Simultaneously, you can observe the changes in the Mobile Price and Count by using Sliders.
 
- ![](Getting-Started_images/Getting-Started_img1.png)
+ ![Mobile Price and Count by using Sliders.](Getting-Started_images/Getting-Started_img1.png)
 
 
 
@@ -201,7 +201,7 @@ function show() {
 
 The following screenshot illustrates the final output in the Slider creation.
 
- ![](Getting-Started_images/Getting-Started_img2.png)
+ ![illustrates the final output in the Slider creation.](Getting-Started_images/Getting-Started_img2.png)
 
 
 
@@ -461,7 +461,7 @@ function calculate() {
 
  The following screenshot displays the calculated EMI amount by using Slider.
 
- ![](Getting-Started_images/Getting-Started_img3.png)
+ ![displays the calculated EMI amount by using Slider.](Getting-Started_images/Getting-Started_img3.png)
 
 
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204026/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha