### PR TITLE
SEO-204825-Asp.net-Webforms-H1tag-missing-Hotfix 

### DIFF
--- a/aspnet/Grid/How-to/Getting-Datasource-of-Grid-in-Sorted-order.md
+++ b/aspnet/Grid/How-to/Getting-Datasource-of-Grid-in-Sorted-order.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Datasource of Grid in Sorted Order | Grid | ASP.NET Webforms | Syncfusion
-description: Getting Datasource of Grid in Sorted Order
+title: Getting Datasource of Grid in Sorted Order | Grid | ASP.NET Webforms
+description: Check out and learn here all about getting datasource of Syncfusion Grid in Sorted Order and much more details.
 platform: aspnet
 control: Grid
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 tag missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |

Regards, 
Asha